### PR TITLE
Added GrpcService types to protobuf node in .csproj

### DIFF
--- a/Grpc.Client/Grpc.Client.csproj
+++ b/Grpc.Client/Grpc.Client.csproj
@@ -7,7 +7,7 @@
 
 
   <ItemGroup>
-    <Protobuf Include="Protos\price.proto" />
+    <Protobuf Include="Protos\price.proto" GrpcServices="Client" />
   </ItemGroup>
 
 

--- a/Grpc.PricingService/Grpc.PricingService.csproj
+++ b/Grpc.PricingService/Grpc.PricingService.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
  
   <ItemGroup>
-    <Protobuf Include="Protos\price.proto" />
+    <Protobuf Include="Protos\price.proto" GrpcServices="Server" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
To auto generate service and classes, csproj file should to contain "GrpcServices" attribute at proto node with "server" or "client" value. By default, this value set as "Both"

Refer: [https://docs.microsoft.com/en-us/aspnet/core/grpc/basics?view=aspnetcore-5.0](MSFT G-RPC Basics Docs.)